### PR TITLE
Add user-local 2GIS API keys xcconfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 #
 # gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
 
+## User-local 2GIS settings (not committed).
+/Local.xcconfig
+
 ## User settings
 xcuserdata/
 

--- a/README.md
+++ b/README.md
@@ -29,14 +29,22 @@ iOS Native SDK от 2GIS позволяет добавить [карту 2GIS](h
 2. Откройте проект `app.xcodeproj` и задайте ваши ключи API в файле `Info.plist` проекта:
 
    ```
-   dgisMapApiKey=YOUR_MAP_KEY
-   dgisDirectoryApiKey=YOUR_DIRECTIONS_KEY
+   DGISMapAPIKey = YOUR_MAP_KEY
+   DGISDirectoryAPIKey = YOUR_DIRECTORY_KEY
    ```
+
+   Или создайте в корне репозитория файл Local.xcconfig с вашими ключами (файл включён в .gitignore):
+   ```
+   DGIS_MAP_API_KEY = xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+   DGIS_DIRECTORY_API_KEY = xxxxxxxxxx
+   ```
+
+   Если соответствующая функциональность не нужна, можно оставить эти значения.
 
 3. Дождитесь загрузки зависимостей Swift. Эта операция может занять длительное время.
 
    Вы не сможете собрать и запустить проект, пока не будут загружены зависимости.
- 
+
 4. Соберите и запустите проект (⌘+R).
 
 

--- a/app.xcodeproj/project.pbxproj
+++ b/app.xcodeproj/project.pbxproj
@@ -80,6 +80,7 @@
 		0991909525B96E1C00F4235B /* MapControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapControl.swift; sourceTree = "<group>"; };
 		09C834FA25BFCD5800D347F4 /* RouteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteView.swift; sourceTree = "<group>"; };
 		09C834FC25BFCD8500D347F4 /* RouteViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteViewModel.swift; sourceTree = "<group>"; };
+		4B0E899D260DEC6B00491C71 /* DGIS.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = DGIS.xcconfig; sourceTree = "<group>"; };
 		4B1354DB24BCCDC7004E8158 /* NativeApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = NativeApp.entitlements; sourceTree = "<group>"; };
 		4B27063124A3F24C00F12B48 /* NativeApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = NativeApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		4B27063424A3F24C00F12B48 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -202,6 +203,7 @@
 				4B27063D24A3F25000F12B48 /* Assets.xcassets */,
 				4B27063F24A3F25000F12B48 /* LaunchScreen.storyboard */,
 				4B27064224A3F25000F12B48 /* Info.plist */,
+				4B0E899D260DEC6B00491C71 /* DGIS.xcconfig */,
 			);
 			path = app;
 			sourceTree = "<group>";
@@ -548,6 +550,7 @@
 		};
 		4B27064624A3F25000F12B48 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 4B0E899D260DEC6B00491C71 /* DGIS.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = app/NativeApp.entitlements;
@@ -569,6 +572,7 @@
 		};
 		4B27064724A3F25000F12B48 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 4B0E899D260DEC6B00491C71 /* DGIS.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = app/NativeApp.entitlements;

--- a/app/DGIS.xcconfig
+++ b/app/DGIS.xcconfig
@@ -1,0 +1,6 @@
+// Configuration settings file format documentation can be found at:
+// https://help.apple.com/xcode/#/dev745c5c974
+
+// Enter your 2GIS API keys below (without quotes).
+DGIS_MAP_API_KEY =
+DGIS_DIRECTORY_API_KEY =

--- a/app/DGIS.xcconfig
+++ b/app/DGIS.xcconfig
@@ -1,6 +1,12 @@
 // Configuration settings file format documentation can be found at:
 // https://help.apple.com/xcode/#/dev745c5c974
 
-// Enter your 2GIS API keys below (without quotes).
-DGIS_MAP_API_KEY =
-DGIS_DIRECTORY_API_KEY =
+// Create a local file (Local.xcconfig) in the repo root,
+// like the following:
+//
+// // Enter your 2GIS API keys below (without quotes).
+// DGIS_MAP_API_KEY = xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+// DGIS_DIRECTORY_API_KEY = xxxxxxxxxx
+//
+
+#include? "../Local.xcconfig"

--- a/app/Info.plist
+++ b/app/Info.plist
@@ -21,9 +21,9 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>DGISDirectoryAPIKey</key>
-	<string></string>
+	<string>$(DGIS_DIRECTORY_API_KEY)</string>
 	<key>DGISMapAPIKey</key>
-	<string></string>
+	<string>$(DGIS_MAP_API_KEY)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>


### PR DESCRIPTION
См. README за пояснениями об использовании.

Чтобы каждый раз не обновлять Info.plist настройками вручную, подключаем игнорируемый Local.xcconfig, в котором эти настройки задаются. В Info.plist оставляем переменные.